### PR TITLE
Problem with the Library

### DIFF
--- a/.yo-rc.json
+++ b/.yo-rc.json
@@ -1,7 +1,7 @@
 {
   "generator-angular2-library": {
     "promptValues": {
-      "gitRepositoryUrl": "https://github.com/sabyasachibiswal/angular5-social-login"
+      "gitRepositoryUrl": "https://github.com/high54/angular-6-social-login/issues"
     }
   }
 }

--- a/README.MD
+++ b/README.MD
@@ -3,7 +3,7 @@
 
 Social login api for Angular 6. Includes Facebook, Google login and Linkedin. 
 
-![Travis](https://img.shields.io/travis/USER/REPO.svg?style=flat-square)
+build | passing
 
 
 [AOT](https://angular.io/guide/aot-compiler) Compatible.

--- a/README.MD
+++ b/README.MD
@@ -1,6 +1,10 @@
 # Original project : sabyasachibiswal https://github.com/sabyasachibiswal/angular5-social-login
 
-Social login api for Angular 6. Includes Facebook, Google login and Linkedin.  
+
+Social login api for Angular 6. Includes Facebook, Google login and Linkedin. 
+
+![Travis](https://img.shields.io/travis/USER/REPO.svg?style=flat-square)
+
 
 [AOT](https://angular.io/guide/aot-compiler) Compatible.
 

--- a/README.MD
+++ b/README.MD
@@ -3,7 +3,7 @@
 
 Social login api for Angular 6. Includes Facebook, Google login and Linkedin. 
 
-[![Generic badge](https://img.shields.io/badge/build-passing-green.svg)]
+![Generic badge](https://img.shields.io/badge/build-passing-green.svg)
 
 [AOT](https://angular.io/guide/aot-compiler) Compatible.
 

--- a/README.MD
+++ b/README.MD
@@ -4,7 +4,7 @@
 Social login api for Angular 6. Includes Facebook, Google login and Linkedin. 
 
 ![Generic badge](https://img.shields.io/badge/build-passing-green.svg)
-
+![Generic badge](https://img.shields.io/badge/Angular-6-green.svg)
 [AOT](https://angular.io/guide/aot-compiler) Compatible.
 
 

--- a/README.MD
+++ b/README.MD
@@ -29,6 +29,7 @@ import {
     AuthServiceConfig,
     GoogleLoginProvider,
     FacebookLoginProvider,
+    LinkedinLoginProvider,
 } from "angular-6-social-login";
 
 

--- a/README.MD
+++ b/README.MD
@@ -3,8 +3,7 @@
 
 Social login api for Angular 6. Includes Facebook, Google login and Linkedin. 
 
-build | passing
-
+[![Generic badge](https://img.shields.io/badge/build-passing-green.svg)]
 
 [AOT](https://angular.io/guide/aot-compiler) Compatible.
 

--- a/README.MD
+++ b/README.MD
@@ -37,7 +37,7 @@ export function getAuthServiceConfigs() {
         },
         {
           id: GoogleLoginProvider.PROVIDER_ID,
-	      provider: new GoogleLoginProvid("Your-Google-Client-Id")
+	      provider: new GoogleLoginProvider("Your-Google-Client-Id")
         },
       ];
   );
@@ -98,7 +98,7 @@ export class SigninComponent implements OnInit {
       (userData) => {
         console.log(socialPlatform+" sign in data : " , userData);
         // Now sign-in with userData
-        ...
+        // ...
             
       }
     );
@@ -117,7 +117,7 @@ In `signin.component.html`,
 </h1>
 
 <button (click)="socialSignIn('facebook')">Sign in with Facebook</button>
-<button (click)="socialSignIn('google')">Signin in with Google</button>              
+<button (click)="socialSignIn('google')">Sign in with Google</button>              
 ```
 
 

--- a/README.MD
+++ b/README.MD
@@ -1,6 +1,6 @@
 # Original project : sabyasachibiswal https://github.com/sabyasachibiswal/angular5-social-login
 
-Social login api for Angular 6. Includes Facebook and Google login.  
+Social login api for Angular 6. Includes Facebook, Google login and Linkedin.  
 
 [AOT](https://angular.io/guide/aot-compiler) Compatible.
 

--- a/README.MD
+++ b/README.MD
@@ -1,4 +1,4 @@
-Social login api for Angular 5. Includes Facebook and Google login.  
+Social login api for Angular 6. Includes Facebook and Google login.  
 
 [AOT](https://angular.io/guide/aot-compiler) Compatible.
 
@@ -9,7 +9,7 @@ Social login api for Angular 5. Includes Facebook and Google login.
 ### Install via npm 
 
 ```sh
-npm install --save angular5-social-login
+npm install --save angular-6-social-login
 ```
 
 ### Import the module

--- a/README.MD
+++ b/README.MD
@@ -1,3 +1,5 @@
+# Original project : sabyasachibiswal https://github.com/sabyasachibiswal/angular5-social-login
+
 Social login api for Angular 6. Includes Facebook and Google login.  
 
 [AOT](https://angular.io/guide/aot-compiler) Compatible.
@@ -24,7 +26,7 @@ import {
     AuthServiceConfig,
     GoogleLoginProvider,
     FacebookLoginProvider,
-} from "angular5-social-login";
+} from "angular-6-social-login";
 
 
 // Configs 
@@ -39,6 +41,10 @@ export function getAuthServiceConfigs() {
           id: GoogleLoginProvider.PROVIDER_ID,
 	      provider: new GoogleLoginProvider("Your-Google-Client-Id")
         },
+          {
+            id: LinkedinLoginProvider.PROVIDER_ID,
+            provider: new LinkedinLoginProvider("1098828800522-m2ig6bieilc3tpqvmlcpdvrpvn86q4ks.apps.googleusercontent.com")
+          },
       ];
   );
   return config;
@@ -73,7 +79,7 @@ import {
     AuthService,
     FacebookLoginProvider,
     GoogleLoginProvider
-} from 'angular5-social-login';
+} from 'angular-6-social-login';
 
 @Component({
   selector: 'app-signin',
@@ -92,6 +98,8 @@ export class SigninComponent implements OnInit {
       socialPlatformProvider = FacebookLoginProvider.PROVIDER_ID;
     }else if(socialPlatform == "google"){
       socialPlatformProvider = GoogleLoginProvider.PROVIDER_ID;
+    } else if (socialPlatform == "linkedin") {
+      socialPlatformProvider = LinkedinLoginProvider.PROVIDER_ID;
     }
     
     this.socialAuthService.signIn(socialPlatformProvider).then(

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -131,7 +131,7 @@ gulp.task('rollup:umd', function () {
       // The name to use for the module for UMD/IIFE bundles
       // (required for bundles with exports)
       // See https://github.com/rollup/rollup/wiki/JavaScript-API#modulename
-      // moduleName: 'angular5-social-login',
+      // moduleName: 'angular-6-social-login',
       name: 'angular-6-social-login',
 
       // See https://github.com/rollup/rollup/wiki/JavaScript-API#globals

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -132,7 +132,7 @@ gulp.task('rollup:umd', function () {
       // (required for bundles with exports)
       // See https://github.com/rollup/rollup/wiki/JavaScript-API#modulename
       // moduleName: 'angular5-social-login',
-      name: 'angular5-social-login',
+      name: 'angular-6-social-login',
 
       // See https://github.com/rollup/rollup/wiki/JavaScript-API#globals
       globals: {
@@ -140,7 +140,7 @@ gulp.task('rollup:umd', function () {
       }
 
     }))
-    .pipe(rename('angular5-social-login.umd.js'))
+    .pipe(rename('angular-6-social-login.umd.js'))
     .pipe(gulp.dest(distFolder));
 });
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
-  "name": "angular5-social-login",
-  "version": "1.0.9",
-  "description": "Agular 5 : Social Login (Facebook and Google)",
+  "name": "angular-6-social-login",
+  "version": "1.1.0",
+  "description": "Agular 6 : Social Login (Facebook and Google)",
   "scripts": {
     "build": "gulp build",
     "build:watch": "gulp",
@@ -13,25 +13,26 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/sabyasachibiswal/angular5-social-login"
+    "url": "https://github.com/high54/angular-6-social-login"
   },
   "author": {
-    "name": "Sabyasachi Biswal",
-    "email": "sabyasachi.biswal4@gmail.com"
+    "name": "Julien Bertacco",
+    "email": "julien.bertacco@gmail.com"
   },
   "keywords": [
     "angular",
-    "angular5",
-    "ng5",
+    "angular6",
+    "ng6",
     "angular social login",
     "angular facebook login",
     "angular google login",
-    "angular 5 social login",
-    "angular5 social login",
+    "angular 6 social login",
+    "angular6 social login",
     "social authentication",
     "angular social authentication",
     "angular-social-login",
-    "angular5-social-login",
+    "angular6-social-login",
+    "angular-6-social-login",
     "social-authentication",
     "social-login",
     "google-authentication",
@@ -42,7 +43,7 @@
   ],
   "license": "MIT",
   "bugs": {
-    "url": "https://github.com/sabyasachibiswal/angular5-social-login/issues"
+    "url": "https://github.com/high54/angular-6-social-login/issues"
   },
   "devDependencies": {
     "@angular/common": "^4.0.0",

--- a/src/auth.service.ts
+++ b/src/auth.service.ts
@@ -1,7 +1,7 @@
 import { Injectable } from '@angular/core';
 
-import { Observable } from 'rxjs/Observable';
-import { BehaviorSubject } from 'rxjs/BehaviorSubject';
+import { Observable } from 'rxjs';
+import { BehaviorSubject } from 'rxjs';
 
 import { LoginProvider } from './entities/login-provider';
 import { SocialUser } from './entities/user';

--- a/src/package.json
+++ b/src/package.json
@@ -1,28 +1,29 @@
 {
-  "name": "angular5-social-login",
-  "version": "1.0.9",
-  "description": "Agular 5 : Social Login (Facebook and Google)",
+  "name": "angular-6-social-login",
+  "version": "1.1.0",
+  "description": "Agular 6 : Social Login (Facebook and Google)",
   "repository": {
     "type": "git",
-    "url": "https://github.com/sabyasachibiswal/angular5-social-login"
+    "url": "https://github.com/high54/angular-6-social-login"
   },
   "author": {
-    "name": "Sabyasachi Biswal",
-    "email": "sabyasachi.biswal4@gmail.com"
+    "name": "Julien Bertacco",
+    "email": "julien.bertacco@gmail.com"
   },
   "keywords": [
     "angular",
-    "angular5",
-    "ng5",
+    "angular6",
+    "ng6",
     "angular social login",
     "angular facebook login",
     "angular google login",
-    "angular 5 social login",
-    "angular5 social login",
+    "angular 6 social login",
+    "angular6 social login",
     "social authentication",
     "angular social authentication",
     "angular-social-login",
-    "angular5-social-login",
+    "angular6-social-login",
+    "angular-6-social-login",
     "social-authentication",
     "social-login",
     "google-authentication",
@@ -33,7 +34,7 @@
   ],
   "license": "MIT",
   "bugs": {
-    "url": "https://github.com/sabyasachibiswal/angular5-social-login/issues"
+    "url": "https://github.com/high54/angular-6-social-login/issues"
   },
   "main": "angular5-social-login.umd.js",
   "module": "angular5-social-login.js",

--- a/src/package.json
+++ b/src/package.json
@@ -36,10 +36,10 @@
   "bugs": {
     "url": "https://github.com/high54/angular-6-social-login/issues"
   },
-  "main": "angular5-social-login.umd.js",
-  "module": "angular5-social-login.js",
-  "jsnext:main": "angular5-social-login.js",
-  "typings": "angular5-social-login.d.ts",
+  "main": "angular-6-social-login.umd.js",
+  "module": "angular-6-social-login.js",
+  "jsnext:main": "angular-6-social-login.js",
+  "typings": "angular-6-social-login.d.ts",
   "peerDependencies": {
     "@angular/common": "^5.0.0",
     "@angular/core": "^5.0.0",

--- a/src/tsconfig.es5.json
+++ b/src/tsconfig.es5.json
@@ -21,8 +21,8 @@
     "annotateForClosureCompiler": true,
     "strictMetadataEmit": true,
     "skipTemplateCodegen": true,
-    "flatModuleOutFile": "angular5-social-login.js",
-    "flatModuleId": "angular5-social-login"
+    "flatModuleOutFile": "angular-6-social-login.js",
+    "flatModuleId": "angular-6-social-login"
   },
   "files": [
     "./index.ts"


### PR DESCRIPTION
Refused to load the script 'https://ssl.gstatic.com/accounts/o/3773663888-v2-idpiframe.js' because it violates the following Content Security Policy directive: "script-src 'report-sample' 'nonce-6atNsNpeH6cpEwiVO5AikQ' 'unsafe-inline' 'strict-dynamic' https: http: 'unsafe-eval'". 'strict-dynamic' is present, so host-based whitelisting is disabled. Note that 'script-src-elem' was not explicitly set, so 'script-src' is used as a fallback.

accounts.google.com/o/oauth2/iframe#origin=http%3A%2F%2Flocalhost%3A4200&rpcToken=1965178898.303193&clearCache=1:1 Refused to execute inline script because it violates the following Content Security Policy directive: "script-src 'report-sample' 'nonce-6atNsNpeH6cpEwiVO5AikQ' 'unsafe-inline' 'strict-dynamic' https: http: 'unsafe-eval'". Note that 'unsafe-inline' is ignored if either a hash or nonce value is present in the source list.